### PR TITLE
Add app review fields to AuthUserResponse schema

### DIFF
--- a/openapi/components/schemas/AppReviewStatus.yaml
+++ b/openapi/components/schemas/AppReviewStatus.yaml
@@ -1,0 +1,7 @@
+type: string
+enum:
+  - PENDING
+  - COMPLETED
+  - PERMANENTLY_DECLINED
+description: App review status indicating user's interaction with app review dialog
+example: "PENDING"

--- a/openapi/components/schemas/AuthUserResponse.yaml
+++ b/openapi/components/schemas/AuthUserResponse.yaml
@@ -40,3 +40,11 @@ properties:
     type: integer
     description: Total number of user logins
     example: 42
+  last_app_review_dialog_shown_at:
+    type: string
+    format: date-time
+    nullable: true
+    description: Last time the app review dialog was shown to the user (nullable)
+    example: "2023-12-25T10:30:00+09:00"
+  app_review_status:
+    $ref: '../schemas/AppReviewStatus.yaml'

--- a/openapi/components/schemas/index.yaml
+++ b/openapi/components/schemas/index.yaml
@@ -1,3 +1,5 @@
+AppReviewStatus:
+  $ref: './AppReviewStatus.yaml'
 AuthUserRequest:
   $ref: './AuthUserRequest.yaml'
 AuthUserResponse:


### PR DESCRIPTION
- Added last_app_review_dialog_shown_at field (nullable datetime)
- Added app_review_status field with AppReviewStatus enum
- Created AppReviewStatus enum (PENDING, COMPLETED, PERMANENTLY_DECLINED)
- Updated schema index to include new AppReviewStatus reference